### PR TITLE
feat: add STATIC_BASE env var to configure asset path

### DIFF
--- a/server/start.js
+++ b/server/start.js
@@ -12,9 +12,10 @@ const __dirname = path.dirname(__filename);
 const {
     PORT = 3000,
     BASE = '',
-    STATIC_BASE = '/static',
     EXPRESS_STATIC
 } = process.env;
+
+const STATIC_BASE = process.env.STATIC_BASE ?? (BASE + '/static');
 
 const app = express();
 

--- a/server/start.js
+++ b/server/start.js
@@ -12,21 +12,22 @@ const __dirname = path.dirname(__filename);
 const {
     PORT = 3000,
     BASE = '',
+    STATIC_BASE = '/static',
     EXPRESS_STATIC
 } = process.env;
 
 const app = express();
 
 if (EXPRESS_STATIC) {
-    app.use(BASE + '/static', express.static(path.join(__dirname, '../client/build')))
+    app.use(STATIC_BASE, express.static(path.join(__dirname, '../client/build')))
 }
 
 // app.use('/:lang*?' + BASE, (req, res, next) => {
 //     req.lang = req.params.lang;
 //     next();
-// }, quickstart({navigation, base: BASE}));
+// }, quickstart({navigation, base: BASE, staticBase: STATIC_BASE}));
 
-app.use(quickstart({navigation, base: BASE}));
+app.use(quickstart({navigation, base: BASE, staticBase: STATIC_BASE}));
 
 app.listen(PORT, () => {
     console.log('LISTEN ON ', PORT);


### PR DESCRIPTION
## Problem

`staticBase` (the URL prefix for JS/CSS assets) was hardcoded to `/static` inside `router()` and `start.js` never passed it through. When `BASE=/_quickstart`, the page rendered `<script src="/static/...">` but nginx expected `/_quickstart/static/...` — resulting in 404 for all assets.

## Solution

- `STATIC_BASE` env var, defaults to `BASE + '/static'`
- Passed through to `quickstart()` as `staticBase`
- `EXPRESS_STATIC` middleware also uses `STATIC_BASE`

Fully backwards compatible — without `STATIC_BASE` set, behavior depends on `BASE` as expected.

## Test plan

- [ ] Deploy with `BASE=/_quickstart` (no `STATIC_BASE`) — assets served at `/_quickstart/static/...`
- [ ] Deploy without `BASE` — assets at `/static/...` as before
- [ ] Deploy with explicit `STATIC_BASE` override — uses that value